### PR TITLE
chore(deps): bump copier project template to v0.4.2-35-g3796ebe

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v0.4.2-33-g555d91f
+_commit: v0.4.2-35-g3796ebe
 _src_path: git+https://github.com/twsl/python-project-template
 author_email: 45483159+twsl@users.noreply.github.com
 author_username: twsl

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -89,6 +89,7 @@
                 "autoDocstring.generateDocstringOnEnter": true,
                 "autoDocstring.startOnNewLine": true,
                 "telemetry.telemetryLevel": "off",
+                "git.addAICoAuthor": "off",
                 "files.eol": "\n",
                 "code-eol.highlightNonDefault": true,
                 "code-eol.highlightExtraWhitespace": true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
       - id: pre-commit-update
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.11.7
+    rev: 0.11.8
     hooks:
       - id: uv-lock
 
@@ -64,7 +64,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/allganize/ty-pre-commit
-    rev: v0.0.32
+    rev: v0.0.33
     hooks:
       - id: ty-check
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -42,7 +42,5 @@
     "autoDocstring.startOnNewLine": true,
     "http.proxyStrictSSL": false,
     "telemetry.telemetryLevel": "off",
-    "databricks.python.envFile": "${workspaceFolder}/.env",
-    "jupyter.interactiveWindow.cellMarker.codeRegex": "^# COMMAND ----------|^# Databricks notebook source|^(#\\s*%%|#\\s*\\<codecell\\>|#\\s*In\\[\\d*?\\]|#\\s*In\\[ \\])",
-    "jupyter.interactiveWindow.cellMarker.default": "# COMMAND ----------"
+    "git.addAICoAuthor": "off"
 }


### PR DESCRIPTION
This PR updates files via copier. In case of conflicts, the PR will always reflect the latest copier output.